### PR TITLE
Fix createdAt parameter always set to 0 in archive

### DIFF
--- a/archive/src/main/java/io/orkes/conductor/dao/archive/ArchivedExecutionDAO.java
+++ b/archive/src/main/java/io/orkes/conductor/dao/archive/ArchivedExecutionDAO.java
@@ -197,13 +197,6 @@ public class ArchivedExecutionDAO implements ExecutionDAO {
 
     @Override
     public String createWorkflow(WorkflowModel workflow) {
-        // UUID used are time based and we want to keep the created time of the UUID with the create
-        // time of workflow
-        // The reason is that the create time is used for partitioning and
-        // we want to be able to get the create time from workflow id
-        long time = TimeBasedUUIDGenerator.getDate(workflow.getWorkflowId());
-        workflow.setCreateTime(time);
-
         return metricsCollector
                 .getTimer("create_workflow_dao", "workflowName", workflow.getWorkflowName())
                 .record(


### PR DESCRIPTION
The original archive version assumes redis as execution DAO backend where UUID of workflows contains creation time and uses UUID to extract creation time and overwrites the original value.

Since we are not using redis, this does not work and the result of extraction is always 0.

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>