### PR TITLE
Add lucene dependency for e2e tests with ES

### DIFF
--- a/persistence/postgres-persistence/build.gradle
+++ b/persistence/postgres-persistence/build.gradle
@@ -26,6 +26,9 @@ dependencies {
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:6.8.23"
     testImplementation "org.elasticsearch.client:elasticsearch-rest-high-level-client:6.8.23"
     testImplementation "org.testcontainers:elasticsearch:${revTestContainer}"
+    //Lucene
+    testImplementation "org.apache.lucene:lucene-core:7.7.3"
+    testImplementation "org.apache.lucene:lucene-analyzers-common:7.7.3"
 
     testImplementation project(":conductor-server")
     testImplementation project(":conductor-client")


### PR DESCRIPTION
For some reason elasticsearch 6 persistence could no longer find Lucene on classpath.