### PR TITLE
create postgres advisory lock DAO

### DIFF
--- a/community-server/src/main/resources/application.properties
+++ b/community-server/src/main/resources/application.properties
@@ -128,3 +128,13 @@ management.metrics.export.datadog.enabled=false
 #optional - default Datadog instance is https://app.datadoghq.com/ 
 # management.metrics.export.datadog.uri=<your DD instance>
 #management.metrics.export.datadog.step=10s
+
+#### START Postgres lock configuration ####
+
+spring.postgreslock.url=jdbc:tc:postgresql:11.15-alpine:///conductor
+spring.postgreslock.username=postgres
+spring.postgreslock.password=postgres
+spring.postgreslock.leaseTime=5000
+spring.postgreslock.timeToRetry=500
+
+#### END Postgres lock configuration ####

--- a/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
+++ b/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
@@ -109,6 +109,7 @@ public class PostgresConfiguration {
         return retryTemplate;
     }
 
+    @Bean
     public DataSource createLockDataSource() {
         HikariDataSource ds = new HikariDataSource();
         ds.setJdbcUrl(properties.getLockDbUrl());
@@ -120,7 +121,7 @@ public class PostgresConfiguration {
     @Bean
     public PostgresLockDAO postgresLockDAO(
             @Qualifier("postgresRetryTemplate") RetryTemplate retryTemplate,
-            ObjectMapper objectMapper, DataSource ds) {
+            ObjectMapper objectMapper, @Qualifier("createLockDataSource") DataSource ds) {
         return new PostgresLockDAO(retryTemplate, objectMapper, ds, properties);
     }
 

--- a/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
+++ b/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
@@ -19,8 +19,11 @@ import javax.sql.DataSource;
 
 import com.netflix.conductor.dao.ExecutionDAO;
 import com.netflix.conductor.postgres.config.outbox.OutboxExecutionDAO;
+import com.netflix.conductor.postgres.dao.PostgresLockDAO;
+import com.zaxxer.hikari.HikariDataSource;
 import org.flywaydb.core.Flyway;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -55,6 +58,15 @@ public class PostgresConfiguration {
         this.dataSource = dataSource;
         this.properties = properties;
     }
+
+    @Value("${spring.datasource.url}")
+    private String dbUrl;
+
+    @Value("${spring.datasource.username}")
+    private String dbUsername;
+
+    @Value("${spring.datasource.password}")
+    private String dbPassword;
 
     @Bean(initMethod = "migrate")
     @PostConstruct

--- a/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
+++ b/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresConfiguration.java
@@ -106,6 +106,19 @@ public class PostgresConfiguration {
         return retryTemplate;
     }
 
+    @Bean
+    public PostgresLockDAO postgresLockDAO(
+            @Qualifier("postgresRetryTemplate") RetryTemplate retryTemplate,
+            ObjectMapper objectMapper) {
+        HikariDataSource ds = new HikariDataSource();
+        ds.setJdbcUrl(dbUrl);
+        ds.setUsername(dbUsername);
+        ds.setPassword(dbPassword);
+        ds.setAutoCommit(false);
+        ds.setMaximumPoolSize(1);
+        return new PostgresLockDAO(retryTemplate, objectMapper, ds);
+    }
+
     public static class CustomRetryPolicy extends SimpleRetryPolicy {
 
         private static final String ER_LOCK_DEADLOCK = "40P01";

--- a/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresProperties.java
+++ b/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/config/PostgresProperties.java
@@ -23,6 +23,21 @@ public class PostgresProperties {
     @Value("${conductor.outbox.table.enabled:false}")
     private boolean outboxEnabled;
 
+    @Value("${spring.postgreslock.datasource.url}")
+    private String dbUrl;
+
+    @Value("${spring.postgreslock.datasource.username}")
+    private String dbUsername;
+
+    @Value("${spring.postgreslock.datasource.password}")
+    private String dbPassword;
+
+    @Value("${spring.postgreslock.datasource.leaseTime}")
+    private long DEFAULT_LEASE_TIME;
+
+    @Value("${spring.postgreslock.datasource.timeToTry}")
+    private long DEFAULT_TIME_TO_TRY;
+
     /** The time in seconds after which the in-memory task definitions cache will be invalidated */
     @DurationUnit(ChronoUnit.SECONDS)
     private Duration taskDefCacheRefreshInterval = Duration.ofSeconds(60);
@@ -78,4 +93,24 @@ public class PostgresProperties {
     }
 
     public boolean isOutboxEnabled() { return outboxEnabled; }
+
+    public String getLockDbUrl() {
+        return dbUrl;
+    }
+
+    public String getLockDbUsername() {
+        return dbUsername;
+    }
+
+    public String getLockDbPassword() {
+        return dbPassword;
+    }
+
+    public long getDefaultLeaseTime() {
+        return DEFAULT_LEASE_TIME;
+    }
+
+    public long getDefaultTimeToTry() {
+        return DEFAULT_TIME_TO_TRY;
+    }
 }

--- a/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresLockDAO.java
+++ b/persistence/postgres-persistence/src/main/java/com/netflix/conductor/postgres/dao/PostgresLockDAO.java
@@ -1,0 +1,130 @@
+package com.netflix.conductor.postgres.dao;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.conductor.core.sync.Lock;
+import com.netflix.conductor.model.TaskModel;
+import com.netflix.conductor.postgres.util.Query;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.retry.support.RetryTemplate;
+
+import javax.sql.DataSource;
+import java.util.concurrent.*;
+
+public class PostgresLockDAO extends PostgresBaseDAO implements Lock {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PostgresLockDAO.class);
+    private static final ConcurrentHashMap<String, ScheduledFuture<?>> SCHEDULEDFUTURES =
+            new ConcurrentHashMap<>();
+    private static final ThreadGroup THREAD_GROUP = new ThreadGroup("PostgresLock-scheduler");
+    private static final ThreadFactory THREAD_FACTORY =
+            runnable -> new Thread(THREAD_GROUP, runnable);
+    private static final ScheduledExecutorService SCHEDULER =
+            Executors.newScheduledThreadPool(1, THREAD_FACTORY);
+    protected PostgresLockDAO(RetryTemplate retryTemplate, ObjectMapper objectMapper, DataSource dataSource) {
+        super(retryTemplate, objectMapper, dataSource);
+    }
+
+    @Override
+    public void acquireLock(String lockId) {
+        LOGGER.trace("Acquiring lock {}", lockId);
+        // create code for acquiring advisory lock in postgres
+        final String ADVISORY_LOCK = "SELECT pg_advisory_lock (?)";
+
+        // execute the query
+        queryWithTransaction(ADVISORY_LOCK, (q) -> {
+            q.addParameter(lockId);
+            q.executeQuery();
+
+            return q;
+        });
+    }
+
+    @Override
+    public boolean acquireLock(String lockId, long timeToTry, TimeUnit unit) {
+        final String TRY_ADVISORY_LOCK =
+                "DECLARE\n" +
+                        "  lock_acquired boolean;\n" +
+                        "  start_time timestamp;\n" +
+                        "BEGIN\n" +
+                        "  start_time := now();\n" +
+                        "\n" +
+                        "  lock_acquired := pg_try_advisory_lock(?);\n" +
+                        "\n" +
+                        "WHILE NOT lock_acquired AND start_time + INTERVAL '? ?' < now() LOOP\n" +
+                        "  PERFORM pg_sleep(0.5);\n" +
+                        "  lock_acquired := pg_try_advisory_lock(?);\n" +
+                        "END LOOP;\n" +
+                        "\n" +
+                        "SELECT lock_acquired;\n" +
+                        "\n" +
+                        "END;";
+
+        Query query = queryWithTransaction(TRY_ADVISORY_LOCK, (q) -> {
+            q.addParameter(lockId);
+            q.addParameter(timeToTry);
+            q.addParameter(unit.toString());
+            q.addParameter(lockId);
+
+            return q;
+        });
+
+        return query.executeAndFetchFirst(Boolean.class);
+    }
+
+    @Override
+    public boolean acquireLock(String lockId, long timeToTry, long leaseTime, TimeUnit unit) {
+        final String TRY_ADVISORY_LOCK =
+                "DECLARE\n" +
+                        "  lock_acquired boolean;\n" +
+                        "  start_time timestamp;\n" +
+                        "BEGIN\n" +
+                        "  start_time := now();\n" +
+                        "\n" +
+                        "  lock_acquired := pg_try_advisory_lock(?);\n" +
+                        "\n" +
+                        "WHILE NOT lock_acquired AND start_time + INTERVAL '? ?' < now() LOOP\n" +
+                        "  PERFORM pg_sleep(0.5);\n" +
+                        "  lock_acquired := pg_try_advisory_lock(?);\n" +
+                        "END LOOP;\n" +
+                        "\n" +
+                        "SELECT lock_acquired;\n" +
+                        "\n" +
+                        "END;";
+
+        Query query = queryWithTransaction(TRY_ADVISORY_LOCK, (q) -> {
+            q.addParameter(lockId);
+            q.addParameter(timeToTry);
+            q.addParameter(unit.toString());
+            q.addParameter(lockId);
+            q.executeQuery();
+
+            return q;
+        });
+
+        SCHEDULEDFUTURES.put(
+                lockId, SCHEDULER.schedule(() -> deleteLock(lockId), leaseTime, unit)
+        );
+
+        return query.executeAndFetchFirst(Boolean.class);
+    }
+
+    @Override
+    public void releaseLock(String lockId) {
+        final String ADVISORY_UNLOCK = "SELECT pg_advisory_unlock (?)";
+
+        queryWithTransaction(ADVISORY_UNLOCK, (q) -> {
+            q.addParameter(lockId);
+            q.executeQuery();
+
+            return q;
+        });
+
+        SCHEDULEDFUTURES.remove(lockId);
+    }
+
+    @Override
+    public void deleteLock(String lockId) {
+        releaseLock(lockId);
+    }
+
+}

--- a/persistence/postgres-persistence/src/main/resources/db/migration_postgres/V9_advisory_lock.sql
+++ b/persistence/postgres-persistence/src/main/resources/db/migration_postgres/V9_advisory_lock.sql
@@ -1,0 +1,29 @@
+CREATE OR REPLACE PROCEDURE acquire_advisory_lock(lock_id INTEGER, time_to_try INTEGER, unit VARCHAR DEFAULT 'SECOND')
+LANGUAGE PLPGSQL
+AS $$
+BEGIN
+  DECLARE
+lock_acquired BOOLEAN;
+    start_time TIMESTAMP;
+
+BEGIN
+        -- Set the start time to the current timestamp
+        start_time := NOW();
+
+        -- Attempt to acquire the advisory lock
+        lock_acquired := pg_try_advisory_lock(lock_id);
+
+        -- While the lock is not acquired and the timeout has not expired
+        WHILE NOT lock_acquired AND start_time + INTERVAL time_to_try || ' ' || unit > NOW() LOOP
+          -- Sleep for 0.5 seconds (500 milliseconds)
+          PERFORM pg_sleep(0.5);
+
+          -- Reattempt to acquire the lock
+          lock_acquired := pg_try_advisory_lock(lock_id);
+END LOOP;
+
+        -- Return the lock acquired status
+SELECT lock_acquired;
+END;
+END;
+$$

--- a/persistence/postgres-persistence/src/main/resources/db/migration_postgres/V9_advisory_lock.sql
+++ b/persistence/postgres-persistence/src/main/resources/db/migration_postgres/V9_advisory_lock.sql
@@ -14,7 +14,7 @@ BEGIN
         lock_acquired := pg_try_advisory_lock(lock_id);
 
         -- While the lock is not acquired and the timeout has not expired
-        WHILE NOT lock_acquired AND start_time + INTERVAL time_to_try || ' ' || unit > NOW() LOOP
+        WHILE NOT lock_acquired AND start_time + INTERVAL time_to_try || ' ' || unit < NOW() LOOP
           -- Sleep for 0.5 seconds (500 milliseconds)
           PERFORM pg_sleep(0.5);
 

--- a/persistence/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresLockDAOTest.java
+++ b/persistence/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresLockDAOTest.java
@@ -15,7 +15,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 @ContextConfiguration(
         classes = {
@@ -49,31 +49,31 @@ public class PostgresLockDAOTest {
     @Test
     public void testAcquireLock() {
         boolean acquiredLock = lockDAO.acquireLock("testLock", 5000, TimeUnit.MILLISECONDS);
-        assertEquals(true, acquiredLock);
+        assertTrue(acquiredLock);
     }
 
     @Test
     public void testAcquireLockTwice() {
         boolean acquiredLock = lockDAO.acquireLock("testLock", 5000, 5000, TimeUnit.MILLISECONDS);
-        assertEquals(true, acquiredLock);
+        assertTrue(acquiredLock);
         acquiredLock = lockDAO.acquireLock("testLock", 2500, TimeUnit.MILLISECONDS);
-        assertEquals(false, acquiredLock);
+        assertFalse(acquiredLock);
     }
 
     @Test
     public void testAcquireLockTwiceWithDifferentLockNames() {
         boolean acquiredLock = lockDAO.acquireLock("testLock", 5000, TimeUnit.MILLISECONDS);
-        assertEquals(true, acquiredLock);
+        assertTrue(acquiredLock);
         acquiredLock = lockDAO.acquireLock("testLock2", 5000, TimeUnit.MILLISECONDS);
-        assertEquals(true, acquiredLock);
+        assertTrue(acquiredLock);
     }
 
     @Test
     public void testReentrantLockWithLessReleasesThanAcquires() {
         boolean acquiredLock = lockDAO.acquireLock("testLock", 5000, TimeUnit.MILLISECONDS);
-        assertEquals(true, acquiredLock);
+        assertTrue(acquiredLock);
         acquiredLock = lockDAO.acquireLock("testLock", 5000, TimeUnit.MILLISECONDS);
-        assertEquals(true, acquiredLock);
+        assertTrue(acquiredLock);
 
         assertEquals(2, lockDAO.scheduledFutures().get("testLock").size());
 
@@ -85,9 +85,9 @@ public class PostgresLockDAOTest {
     @Test
     public void testReentrantLock() {
         boolean acquiredLock = lockDAO.acquireLock("testLock", 5000, TimeUnit.MILLISECONDS);
-        assertEquals(true, acquiredLock);
+        assertTrue(acquiredLock);
         acquiredLock = lockDAO.acquireLock("testLock", 5000, TimeUnit.MILLISECONDS);
-        assertEquals(true, acquiredLock);
+        assertTrue(acquiredLock);
 
         assertEquals(2, lockDAO.scheduledFutures().get("testLock").size());
 
@@ -100,7 +100,7 @@ public class PostgresLockDAOTest {
     @Test
     public void testReleaseLock() {
         boolean acquiredLock = lockDAO.acquireLock("testLock", 5000, TimeUnit.MILLISECONDS);
-        assertEquals(true, acquiredLock);
+        assertTrue(acquiredLock);
         lockDAO.releaseLock("testLock");
         assertEquals(0, lockDAO.scheduledFutures().get("testLock").size());
     }
@@ -108,7 +108,7 @@ public class PostgresLockDAOTest {
     @Test
     public void testReleaseLockTwice() {
         boolean acquiredLock = lockDAO.acquireLock("testLock", 5000, TimeUnit.MILLISECONDS);
-        assertEquals(true, acquiredLock);
+        assertTrue(acquiredLock);
         lockDAO.releaseLock("testLock");
         lockDAO.releaseLock("testLock");
         assertEquals(0, lockDAO.scheduledFutures().get("testLock").size());
@@ -117,7 +117,7 @@ public class PostgresLockDAOTest {
     @Test
     public void testDeleteLock() {
         boolean acquiredLock = lockDAO.acquireLock("testLock", 5000, TimeUnit.MILLISECONDS);
-        assertEquals(true, acquiredLock);
+        assertTrue(acquiredLock);
         lockDAO.deleteLock("testLock");
         assertEquals(0, lockDAO.scheduledFutures().get("testLock").size());
     }

--- a/persistence/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresLockDAOTest.java
+++ b/persistence/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresLockDAOTest.java
@@ -3,13 +3,19 @@ package com.netflix.conductor.postgres.dao;
 import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
 import com.netflix.conductor.postgres.config.PostgresConfiguration;
 import org.flywaydb.core.Flyway;
+import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
 
 @ContextConfiguration(
         classes = {
@@ -31,5 +37,88 @@ public class PostgresLockDAOTest {
     public void before() {
         flyway.clean();
         flyway.migrate();
+    }
+
+    @After
+    public void tearDown() {
+        // Clean caches between tests as they are shared globally
+        lockDAO.scheduledFutures().values().forEach(f -> f.stream().forEach(s -> s.cancel(false)));
+        lockDAO.scheduledFutures().clear();
+    }
+
+    @Test
+    public void testAcquireLock() {
+        boolean acquiredLock = lockDAO.acquireLock("testLock", 5000, TimeUnit.MILLISECONDS);
+        assertEquals(true, acquiredLock);
+    }
+
+    @Test
+    public void testAcquireLockTwice() {
+        boolean acquiredLock = lockDAO.acquireLock("testLock", 5000, 5000, TimeUnit.MILLISECONDS);
+        assertEquals(true, acquiredLock);
+        acquiredLock = lockDAO.acquireLock("testLock", 2500, TimeUnit.MILLISECONDS);
+        assertEquals(false, acquiredLock);
+    }
+
+    @Test
+    public void testAcquireLockTwiceWithDifferentLockNames() {
+        boolean acquiredLock = lockDAO.acquireLock("testLock", 5000, TimeUnit.MILLISECONDS);
+        assertEquals(true, acquiredLock);
+        acquiredLock = lockDAO.acquireLock("testLock2", 5000, TimeUnit.MILLISECONDS);
+        assertEquals(true, acquiredLock);
+    }
+
+    @Test
+    public void testReentrantLockWithLessReleasesThanAcquires() {
+        boolean acquiredLock = lockDAO.acquireLock("testLock", 5000, TimeUnit.MILLISECONDS);
+        assertEquals(true, acquiredLock);
+        acquiredLock = lockDAO.acquireLock("testLock", 5000, TimeUnit.MILLISECONDS);
+        assertEquals(true, acquiredLock);
+
+        assertEquals(2, lockDAO.scheduledFutures().get("testLock").size());
+
+        lockDAO.releaseLock("testLock");
+
+        assertEquals(1, lockDAO.scheduledFutures().get("testLock").size());
+    }
+
+    @Test
+    public void testReentrantLock() {
+        boolean acquiredLock = lockDAO.acquireLock("testLock", 5000, TimeUnit.MILLISECONDS);
+        assertEquals(true, acquiredLock);
+        acquiredLock = lockDAO.acquireLock("testLock", 5000, TimeUnit.MILLISECONDS);
+        assertEquals(true, acquiredLock);
+
+        assertEquals(2, lockDAO.scheduledFutures().get("testLock").size());
+
+        lockDAO.releaseLock("testLock");
+        lockDAO.releaseLock("testLock");
+
+        assertEquals(0, lockDAO.scheduledFutures().get("testLock").size());
+    }
+
+    @Test
+    public void testReleaseLock() {
+        boolean acquiredLock = lockDAO.acquireLock("testLock", 5000, TimeUnit.MILLISECONDS);
+        assertEquals(true, acquiredLock);
+        lockDAO.releaseLock("testLock");
+        assertEquals(0, lockDAO.scheduledFutures().get("testLock").size());
+    }
+
+    @Test
+    public void testReleaseLockTwice() {
+        boolean acquiredLock = lockDAO.acquireLock("testLock", 5000, TimeUnit.MILLISECONDS);
+        assertEquals(true, acquiredLock);
+        lockDAO.releaseLock("testLock");
+        lockDAO.releaseLock("testLock");
+        assertEquals(0, lockDAO.scheduledFutures().get("testLock").size());
+    }
+
+    @Test
+    public void testDeleteLock() {
+        boolean acquiredLock = lockDAO.acquireLock("testLock", 5000, TimeUnit.MILLISECONDS);
+        assertEquals(true, acquiredLock);
+        lockDAO.deleteLock("testLock");
+        assertEquals(0, lockDAO.scheduledFutures().get("testLock").size());
     }
 }

--- a/persistence/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresLockDAOTest.java
+++ b/persistence/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresLockDAOTest.java
@@ -1,0 +1,25 @@
+@ContextConfiguration(
+        classes = {
+                TestObjectMapperConfiguration.class,
+                PostgresConfiguration.class,
+                FlywayAutoConfiguration.class,
+        })
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class PostgresLockDAOTest{
+    @Autowired private PostgresLockDAO lockDAO;
+
+    @Autowired Flyway flyway;
+
+    // clean the database between tests.
+    @Before
+    public void before() {
+        flyway.clean();
+        flyway.migrate();
+    }
+
+    @Override
+    public PostgresLockDAO getLockDAO() {
+        return lockDAO;
+    }
+}

--- a/persistence/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresLockDAOTest.java
+++ b/persistence/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresLockDAOTest.java
@@ -1,3 +1,14 @@
+/*
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 package com.netflix.conductor.postgres.dao;
 
 import com.netflix.conductor.common.config.TestObjectMapperConfiguration;

--- a/persistence/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresLockDAOTest.java
+++ b/persistence/postgres-persistence/src/test/java/com/netflix/conductor/postgres/dao/PostgresLockDAOTest.java
@@ -1,3 +1,16 @@
+package com.netflix.conductor.postgres.dao;
+
+import com.netflix.conductor.common.config.TestObjectMapperConfiguration;
+import com.netflix.conductor.postgres.config.PostgresConfiguration;
+import org.flywaydb.core.Flyway;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
 @ContextConfiguration(
         classes = {
                 TestObjectMapperConfiguration.class,
@@ -6,20 +19,17 @@
         })
 @RunWith(SpringRunner.class)
 @SpringBootTest
-public class PostgresLockDAOTest{
-    @Autowired private PostgresLockDAO lockDAO;
+public class PostgresLockDAOTest {
+    @Autowired
+    private PostgresLockDAO lockDAO;
 
-    @Autowired Flyway flyway;
+    @Autowired
+    Flyway flyway;
 
     // clean the database between tests.
     @Before
     public void before() {
         flyway.clean();
         flyway.migrate();
-    }
-
-    @Override
-    public PostgresLockDAO getLockDAO() {
-        return lockDAO;
     }
 }

--- a/persistence/postgres-persistence/src/test/resources/application.properties
+++ b/persistence/postgres-persistence/src/test/resources/application.properties
@@ -5,3 +5,9 @@ spring.datasource.password=postgres
 spring.datasource.hikari.maximum-pool-size=8
 spring.datasource.hikari.auto-commit=false
 spring.flyway.locations=classpath:db/migration_postgres
+
+spring.postgreslock.url=jdbc:tc:postgresql:11.15-alpine:///conductor
+spring.postgreslock.username=postgres
+spring.postgreslock.password=postgres
+spring.postgreslock.leaseTime=5000
+spring.postgreslock.timeToRetry=500


### PR DESCRIPTION
Added new DAO to handle communication with advisory locks on postgres database
- created new class
- handle synchronization and access to the db node when multiple conductor instances want to change record in db